### PR TITLE
use touch to create docker bind points as files

### DIFF
--- a/scripts/pgap.py
+++ b/scripts/pgap.py
@@ -646,6 +646,10 @@ class Pipeline:
             f.write("--- End YAML Input ---\n\n")
 
             try:
+                # Docker will create a directory rather than a file for binding if the
+                # file does not already exist, so create the file before running the Docker
+                # command
+                subprocess.run(["touch", self.yaml, self.input_dir + "/pgap_input.yaml"])
                 proc = subprocess.Popen(self.cmd, stdout=f, stderr=subprocess.STDOUT)
                 proc.wait()
             finally:


### PR DESCRIPTION
This fixes a problem seen on macOS (#357) where, because the files do not exist before the docker command is run, the docker instance cannot bind, leading to an error:

`PGAP failed, docker exited with rc = 125`

Using `touch` to create the two .yaml files allows `pgap.py` to run to completion. An alternative approach would be to create the files Pythonically, which might technically be safer than the `subprocess.run()` call with `touch`